### PR TITLE
Make ping after discovery concurrent

### DIFF
--- a/hop/hop.go
+++ b/hop/hop.go
@@ -46,7 +46,7 @@ func (s *HopStatistic) Next() {
 		s.TargetIP = addr
 	}
 	s.pingSeq++
-	r, _ := imcp.SendIMCP("0.0.0.0", s.TargetIP, s.TTL, s.PID, s.Timeout, s.pingSeq)
+	r, _ := imcp.SendIMCP("0.0.0.0", s.TargetIP, s.PID, s.Timeout, s.pingSeq)
 	s.Packets = s.Packets.Prev()
 	s.Packets.Value = r
 

--- a/hop/hop.go
+++ b/hop/hop.go
@@ -51,11 +51,14 @@ func (s *HopStatistic) Next() {
 	s.Packets.Value = r
 
 	s.Sent++
-	s.SumElapsed = r.Elapsed + s.SumElapsed
+
 	if !r.Success {
-		s.Lost++
+		return // do not count failed into statistics
 	}
+
+	s.SumElapsed = r.Elapsed + s.SumElapsed
 	s.Last = r
+
 	if s.Best.Elapsed > r.Elapsed {
 		s.Best = r
 	}

--- a/imcp/icmp.go
+++ b/imcp/icmp.go
@@ -15,8 +15,8 @@ type ICMPReturn struct {
 	Elapsed time.Duration
 }
 
-// SendIMCP sends a IMCP to a given destination
-func SendIMCP(localAddr string, dst net.Addr, ttl, pid int, timeout time.Duration) (hop ICMPReturn, err error) {
+// SendIMCP sends a IMCP to a given destination but does allow an IMCP timeout
+func SendDiscoverIMCP(localAddr string, dst net.Addr, ttl, pid int, timeout time.Duration, seq int) (hop ICMPReturn, err error) {
 	hop.Success = false
 	start := time.Now()
 	c, err := icmp.ListenPacket("ip4:icmp", localAddr)
@@ -52,4 +52,85 @@ func SendIMCP(localAddr string, dst net.Addr, ttl, pid int, timeout time.Duratio
 	hop.Addr = peer.String()
 	hop.Success = true
 	return hop, err
+}
+
+// SendIMCP sends a IMCP to a given destination
+func SendIMCP(localAddr string, dst net.Addr, ttl, pid int, timeout time.Duration, seq int) (hop ICMPReturn, err error) {
+	hop.Success = false
+	start := time.Now()
+	c, err := icmp.ListenPacket("ip4:icmp", localAddr)
+	if err != nil {
+		return hop, err
+	}
+	defer c.Close()
+	c.IPv4PacketConn().SetTTL(ttl)
+	c.SetDeadline(time.Now().Add(timeout))
+	wm := icmp.Message{
+		Type: ipv4.ICMPTypeEcho, Code: 0,
+		Body: &icmp.Echo{
+			ID: pid, Seq: 0,
+			Data: []byte("hello"),
+		},
+	}
+	wb, err := wm.Marshal(nil)
+	if err != nil {
+		return hop, err
+	}
+
+	if _, err := c.WriteTo(wb, dst); err != nil {
+		return hop, err
+	}
+
+	_, err = listenForSpecific(time.Now().Add(timeout), dst.String())
+	if err != nil {
+		return hop, err
+	}
+
+	elapsed := time.Since(start)
+	hop.Elapsed = elapsed
+	hop.Addr = dst.String()
+	hop.Success = true
+	return hop, err
+}
+
+// listenForSpecific listens for a reply from a specific destination and returns the body if returned
+func listenForSpecific(deadline time.Time, neededPeer string) (string, error) {
+	conn, err := icmp.ListenPacket("ip4:icmp", "0.0.0.0")
+	if err != nil {
+		return "", err
+	}
+	conn.SetDeadline(deadline)
+	defer conn.Close()
+	for {
+		bytes := make([]byte, 1500)
+		n, peer, err := conn.ReadFrom(bytes)
+		if err != nil {
+			if neterr, ok := err.(*net.OpError); ok {
+				return "", neterr
+			}
+		}
+		if n == 0 {
+			continue
+		}
+
+		if peer.String() != neededPeer {
+			continue
+		}
+
+		x, err := icmp.ParseMessage(1, bytes[:n])
+		if err != nil {
+			continue
+		}
+
+		if x.Type.(ipv4.ICMPType).String() == "time exceeded" {
+			return "", nil
+		}
+
+		if x.Type.(ipv4.ICMPType).String() == "echo reply" {
+			b, _ := x.Body.Marshal(1)
+			return string(b[:2]), nil
+		}
+
+		panic(x.Type.(ipv4.ICMPType).String())
+	}
 }

--- a/imcp/icmp.go
+++ b/imcp/icmp.go
@@ -125,7 +125,7 @@ func listenForSpecific(deadline time.Time, neededPeer, neededBody string) (strin
 		}
 
 		if x.Type.(ipv4.ICMPType).String() == "time exceeded" {
-			return "", nil
+			return "", nil //TODO: add a check for sequences here
 		}
 
 		if x.Type.(ipv4.ICMPType).String() == "echo reply" {

--- a/imcp/icmp.go
+++ b/imcp/icmp.go
@@ -26,7 +26,11 @@ func SendDiscoverIMCP(localAddr string, dst net.Addr, ttl, pid int, timeout time
 		return hop, err
 	}
 	defer c.Close()
-	c.IPv4PacketConn().SetTTL(ttl)
+
+	err = c.IPv4PacketConn().SetTTL(ttl)
+	if err != nil {
+		return hop, err
+	}
 	err = c.SetDeadline(time.Now().Add(timeout))
 	if err != nil {
 		return hop, err
@@ -69,7 +73,10 @@ func SendIMCP(localAddr string, dst net.Addr, target string, ttl, pid int, timeo
 		return hop, err
 	}
 	defer c.Close()
-	c.IPv4PacketConn().SetTTL(ttl)
+	err = c.IPv4PacketConn().SetTTL(ttl)
+	if err != nil {
+		return hop, err
+	}
 	err = c.SetDeadline(time.Now().Add(timeout))
 	if err != nil {
 		return hop, err

--- a/imcp/icmp.go
+++ b/imcp/icmp.go
@@ -17,7 +17,7 @@ type ICMPReturn struct {
 	Elapsed time.Duration
 }
 
-// SendIMCP sends a IMCP to a given destination but does allow an IMCP timeout
+// SendDiscoverIMCP sends a IMCP to a given destination with a TTL to discover hops
 func SendDiscoverIMCP(localAddr string, dst net.Addr, ttl, pid int, timeout time.Duration, seq int) (hop ICMPReturn, err error) {
 	hop.Success = false
 	start := time.Now()
@@ -64,7 +64,7 @@ func SendDiscoverIMCP(localAddr string, dst net.Addr, ttl, pid int, timeout time
 	return hop, err
 }
 
-// SendIMCP sends a IMCP to a given destination
+// SendIMCP sends a IMCP to a given destination which requires a  reply from that specific destination
 func SendIMCP(localAddr string, dst net.Addr, target string, ttl, pid int, timeout time.Duration, seq int) (hop ICMPReturn, err error) {
 	hop.Success = false
 	start := time.Now()

--- a/imcp/icmp.go
+++ b/imcp/icmp.go
@@ -133,9 +133,14 @@ func listenForSpecific(conn *icmp.PacketConn, deadline time.Time, neededPeer, ne
 			index := bytes.Index(body, sent[:4])
 			if index > 0 {
 				x, _ := icmp.ParseMessage(1, body[index:])
-				seq := x.Body.(*icmp.Echo).Seq
-				if seq == needSeq {
-					return peer.String(), "", nil
+				switch x.Body.(type) {
+				case *icmp.Echo:
+					seq := x.Body.(*icmp.Echo).Seq
+					if seq == needSeq {
+						return peer.String(), "", nil
+					}
+				default:
+					// ignore
 				}
 			}
 		}

--- a/mtr/mtr.go
+++ b/mtr/mtr.go
@@ -97,7 +97,7 @@ func (m *MTR) discover(ch chan struct{}) {
 	unknownHopsCount := 0
 	for ttl := 1; ttl < m.maxHops; ttl++ {
 		time.Sleep(m.hopsleep)
-		hopReturn, err := imcp.SendIMCP("0.0.0.0", &ipAddr, ttl, pid, m.timeout)
+		hopReturn, err := imcp.SendDiscoverIMCP("0.0.0.0", &ipAddr, ttl, pid, m.timeout, 1)
 
 		m.mutex.Lock()
 		s := m.registerStatistic(ttl, hopReturn)


### PR DESCRIPTION
I would suggest not to merge this yet. this is my attempt to make the ping concurrent. It seems to work however I am not confident enough to say it fully works.

```
HOP:    Address                Loss%  Sent    Last     Avg    Best   Worst                                             Packets
  1:|-- 192.168.0.1             0.0%     5     3.8     3.4     2.5     4.0                                               .....
  2:|-- 94.110.96.2             0.0%     5    13.3    13.3    11.4    14.5                                               .....
  3:|-- 212.65.36.195           0.0%     5    16.0    16.0    15.3    16.5                                               .....
  4:|-- 213.19.195.193          0.0%     5    19.1    21.0    18.7    24.8                                               .....
  5:|-- 4.69.140.34            80.0%     5     0.0    35.8     0.0    35.8                                               .????
  6:|-- 212.3.235.202           0.0%     5    36.2    36.2    35.4    36.9                                               .....
  7:|-- 195.154.1.119          80.0%     5     0.0    36.6     0.0    36.6                                               .????
  8:|-- ???                   100.0%     1     0.0     0.0     0.0     0.0                                                   ?
  9:|-- ???                   100.0%     1     0.0     0.0     0.0     0.0                                                   ?
 10:|-- ???                   100.0%     1     0.0     0.0     0.0     0.0                                                   ?
 11:|-- ???                   100.0%     1     0.0     0.0     0.0     0.0                                                   ?
 12:|-- 212.47.231.28           0.0%     5    36.3    36.4    35.3    37.0                                               .....
```
(eg not sure if indeed some routers lose 80% or it could be something catching it incorrect)