### PR TITLE
Add missing json marshalling error check

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -49,7 +49,10 @@ var RootCmd = &cobra.Command{
 				}
 			}(ch)
 			m.Run(ch, COUNT)
-			s, _ := pj.Marshal(m)
+			s, err := pj.Marshal(m)
+			if err != nil {
+				return err
+			}
 			fmt.Println(string(s))
 			return nil
 		}


### PR DESCRIPTION
This PR adds a missing error check when the output should be json formatted.