### PR TITLE
Allow multiple IPs per hop

### DIFF
--- a/pkg/hop/hop.go
+++ b/pkg/hop/hop.go
@@ -51,7 +51,7 @@ func (h *HopStatistic) MarshalJSON() ([]byte, error) {
 		Sent:             h.Sent,
 		TTL:              h.TTL,
 		Loss:             h.Loss(),
-		Target:           fmt.Sprintf("%v", h.Targets), // TODO:
+		Target:           fmt.Sprintf("%v", h.Targets),
 		PacketBufferSize: h.RingBufferSize,
 		Last:             h.Last.Elapsed.Seconds() * 1000,
 		Best:             h.Best.Elapsed.Seconds() * 1000,
@@ -143,7 +143,6 @@ func (h *HopStatistic) Render(ptrLookup bool) {
 		i--
 	})
 	l := fmt.Sprintf("%d", h.RingBufferSize)
-
 	gm.Printf("%3d:|-- %-20s  %5.1f%%  %4d  %6.1f  %6.1f  %6.1f  %6.1f  %"+l+"s\n",
 		h.TTL,
 		fmt.Sprintf("%.20s", h.lookupAddr(ptrLookup, 0)),


### PR DESCRIPTION
While using the library, it has been noticed that the packet loss was reported much higher than with other tools (e.g. the original MTR). Investigating the code showed that, after discovering the route, the same IP was always expected at the given hop. As the routes do quite commonly change, this leads to missing assumptions and high packet loss.

This PR adjusts the `discover` method to be used exclusively and removes the `ping` method. This change fixes the high packet loss.
Furthermore, an issue with the sequence numbers and identifiers is fixed, where MTR runs from another goroutine in the same binary were interfering.
On the downside, the pinging will no longer run concurrently.

The CLI is mainly untouched by this PR and shows the first IP at the given hop, but the statistics are otherwise correct (counting all IPs at the given hop). With some effort, probably all IPs at the given hop could be listed, as done by the original MTR.